### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Include `aping-plugin-wikipedia.min.js` in your apiNG application
 <script src="node_modules/aping-plugin-wikipedia/dist/aping-plugin-wikipedia.min.js"></script>
 
 <!-- when using cdn file -->
-<script src="//cdn.jsdelivr.net/aping.plugin-wikipedia/latest/aping-plugin-wikipedia.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/aping-plugin-wikipedia@latest/dist/aping-plugin-wikipedia.min.js"></script>
 
 <!-- when using downloaded files -->
 <script src="aping-plugin-wikipedia.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/aping-plugin-wikipedia.

Feel free to ping me if you have any questions regarding this change.